### PR TITLE
WS2-1278: Add anchor button to basic and full ckeditor profiles.

### DIFF
--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -19,6 +19,7 @@ settings:
         -
           name: Linking
           items:
+            - Anchor
             - DrupalLink
             - DrupalUnlink
         -

--- a/config/install/editor.editor.full_html.yml
+++ b/config/install/editor.editor.full_html.yml
@@ -20,6 +20,7 @@ settings:
         -
           name: Linking
           items:
+            - Anchor
             - DrupalLink
             - DrupalUnlink
         -


### PR DESCRIPTION
This is a change to the editor config yaml files -- making sure it won't cause issues upon update of WS2. I think this will only apply to new sites being spun up, according to the readme?