### PR TITLE
WS2 1247 add webspark webdir

### DIFF
--- a/webspark.info.yml
+++ b/webspark.info.yml
@@ -92,6 +92,7 @@ install:
   - decorative_image_widget
   - block_field
   - webspark_cas
+  - webspark_webdir
 themes:
   - bartik
   - seven

--- a/webspark.install
+++ b/webspark.install
@@ -116,3 +116,12 @@ function webspark_update_9006(&$sandbox) {
 
   $module_installer->install(["webspark_cas"]);
 }
+
+/**
+ * Install webspark_webdir module.
+ */
+function webspark_update_9007(&$sandbox) {
+  $module_installer = \Drupal::service("module_installer");
+
+  $module_installer->install(["webspark_webdir"]);
+}


### PR DESCRIPTION
Installs/enables webspark_webdir module on new and existing sites.