### PR TITLE
WS2-1211: Update the default URL alias for the Basic Page content type

### DIFF
--- a/config/install/pathauto.pattern.basic_page.yml
+++ b/config/install/pathauto.pattern.basic_page.yml
@@ -6,7 +6,7 @@ dependencies:
 id: basic_page
 label: 'Basic Page'
 type: 'canonical_entities:node'
-pattern: '[node:title]'
+pattern: '[node:menu-link:parents:join-path]/[node:title]'
 selection_criteria:
   d1642e7f-74b6-4b95-af08-c3ac769274c3:
     id: node_type


### PR DESCRIPTION
See: https://asudev.jira.com/browse/WS2-1211

It will be important to take note of the comments in this task in order to add the proper wording to the release notes. This change is meant to only affect brand new WS2 websites, however existing sites can “opt-in” to this update as well. Instructions for doing so can be derived from the comments in Jira.