### PR TITLE
WS2-1518: Improve Webspark install experience

### DIFF
--- a/webspark.info.yml
+++ b/webspark.info.yml
@@ -3,6 +3,8 @@ type: profile
 core_version_requirement: ^9.0
 description: 'ASU custom profile.'
 version: 2.8.0
+distribution:
+  name: 'Webspark'
 install:
   # Webspark.
   - node

--- a/webspark.profile
+++ b/webspark.profile
@@ -59,3 +59,10 @@ function webspark_install_tasks_alter(&$tasks, $install_state) {
     'function' => 'Drupal\webspark_installer_forms\Form\WebsparkConfigureGAForm',
   ];
 }
+
+/**
+ * Implements hook_preprocess_template().
+ */
+function webspark_preprocess_install_page(&$variables) {
+  $variables['site_name'] = 'Webspark';
+}


### PR DESCRIPTION
https://asudev.jira.com/browse/WS2-1518

This pull request makes Webspark into a distribution (so there aren't any options to install a different profile) and also overrides the template to say "Webspark" instead of "Drupal" when installing.