### PR TITLE
WS2-1575: Card Arrangement: PNG images not being compressed

### DIFF
--- a/config/install/file_mdm.file_metadata_plugin.getimagesize.yml
+++ b/config/install/file_mdm.file_metadata_plugin.getimagesize.yml
@@ -1,0 +1,7 @@
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/install/file_mdm.settings.yml
+++ b/config/install/file_mdm.settings.yml
@@ -1,0 +1,4 @@
+metadata_cache:
+  enabled: true
+  expiration: 172800
+  disallowed_paths: {  }

--- a/config/install/imagemagick.file_metadata_plugin.imagemagick_identify.yml
+++ b/config/install/imagemagick.file_metadata_plugin.imagemagick_identify.yml
@@ -1,0 +1,7 @@
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/install/imagemagick.settings.yml
+++ b/config/install/imagemagick.settings.yml
@@ -1,0 +1,59 @@
+quality: 75
+binaries: imagemagick
+path_to_binaries: ''
+prepend: ''
+log_warnings: true
+debug: false
+locale: en_US.UTF-8
+image_formats:
+  PNG:
+    mime_type: image/png
+  JPEG:
+    mime_type: image/jpeg
+  JPG:
+    mime_type: image/jpeg
+    weight: 10
+    enabled: false
+  GIF:
+    mime_type: image/gif
+  GIF87:
+    mime_type: image/gif
+    weight: 10
+    enabled: false
+  SVG:
+    mime_type: image/svg+xml
+    enabled: false
+  WEBP:
+    mime_type: image/webp
+  AVIF:
+    mime_type: image/avif
+    enabled: false
+  TIFF:
+    mime_type: image/tiff
+    enabled: false
+  PDF:
+    mime_type: application/pdf
+    enabled: false
+  HEIC:
+    mime_type: image/heif
+    enabled: false
+  BMP:
+    mime_type: image/x-ms-bmp
+    enabled: false
+  PSD:
+    mime_type: image/x-photoshop
+    enabled: false
+  WBMP:
+    mime_type: image/vnd.wap.wbmp
+    enabled: false
+  XBM:
+    mime_type: image/x-xbitmap
+    enabled: false
+  ICO:
+    mime_type: image/vnd.microsoft.icon
+    enabled: false
+advanced:
+  density: 0
+  colorspace: '0'
+  profile: ''
+  coalesce: false

--- a/config/install/sophron.settings.yml
+++ b/config/install/sophron.settings.yml
@@ -1,0 +1,3 @@
+map_option: 0
+map_class: ''
+map_commands: {  }

--- a/config/install/system.image.yml
+++ b/config/install/system.image.yml
@@ -1,0 +1,1 @@
+toolkit: imagemagick

--- a/webspark.info.yml
+++ b/webspark.info.yml
@@ -96,6 +96,9 @@ install:
   - webspark_webdir
   - maxlength
   - field_states_ui
+  - file_mdm
+  - sophron
+  - imagemagick
 themes:
   - bartik
   - seven

--- a/webspark.install
+++ b/webspark.install
@@ -283,4 +283,14 @@ function webspark_update_9013(&$sandbox) {
   $module_installer->install(["file_mdm"]);
   $module_installer->install(["sophron"]);
   $module_installer->install(["imagemagick"]);
+
+  // Importing configs for ImageMagick module.
+  \Drupal::state()->set('configuration_locked', FALSE);
+  \Drupal::service('webspark.config_manager')->importConfigFile('file_mdm.file_metadata_plugin.getimagesize.yml');
+  \Drupal::service('webspark.config_manager')->importConfigFile('file_mdm.settings.yml');
+  \Drupal::service('webspark.config_manager')->importConfigFile('imagemagick.file_metadata_plugin.imagemagick_identify.yml');
+  \Drupal::service('webspark.config_manager')->importConfigFile('imagemagick.settings.yml');
+  \Drupal::service('webspark.config_manager')->importConfigFile('sophron.settings.yml');
+  \Drupal::service('webspark.config_manager')->importConfigFile('system.image.yml');
+  \Drupal::state()->set('configuration_locked', TRUE);
 }

--- a/webspark.install
+++ b/webspark.install
@@ -290,11 +290,11 @@ function webspark_update_9013(&$sandbox) {
 
   // Importing configs for ImageMagick module.
   \Drupal::state()->set('configuration_locked', FALSE);
-  \Drupal::service('webspark.config_manager')->importConfigFile('file_mdm.file_metadata_plugin.getimagesize.yml');
-  \Drupal::service('webspark.config_manager')->importConfigFile('file_mdm.settings.yml');
-  \Drupal::service('webspark.config_manager')->importConfigFile('imagemagick.file_metadata_plugin.imagemagick_identify.yml');
-  \Drupal::service('webspark.config_manager')->importConfigFile('imagemagick.settings.yml');
-  \Drupal::service('webspark.config_manager')->importConfigFile('sophron.settings.yml');
-  \Drupal::service('webspark.config_manager')->importConfigFile('system.image.yml');
+  \Drupal::service('webspark.config_manager')->importConfigFile('file_mdm.file_metadata_plugin.getimagesize');
+  \Drupal::service('webspark.config_manager')->importConfigFile('file_mdm.settings');
+  \Drupal::service('webspark.config_manager')->importConfigFile('imagemagick.file_metadata_plugin.imagemagick_identify');
+  \Drupal::service('webspark.config_manager')->importConfigFile('imagemagick.settings');
+  \Drupal::service('webspark.config_manager')->importConfigFile('sophron.settings');
+  \Drupal::service('webspark.config_manager')->importConfigFile('system.image');
   \Drupal::state()->set('configuration_locked', TRUE);
 }

--- a/webspark.install
+++ b/webspark.install
@@ -273,3 +273,14 @@ function webspark_update_9012(&$sandbox) {
   // Lock the configuration storage.
   \Drupal::state()->set('configuration_locked', TRUE);
 }
+
+/**
+ * Install imagemagick module and dependencies.
+ */
+function webspark_update_9013(&$sandbox) {
+  $module_installer = \Drupal::service("module_installer");
+
+  $module_installer->install(["file_mdm"]);
+  $module_installer->install(["sophron"]);
+  $module_installer->install(["imagemagick"]);
+}


### PR DESCRIPTION
Ticket URL : https://asudev.jira.com/browse/WS2-1575
I installed a new [module](https://www.drupal.org/project/imagemagick) in order to allow PNG quality compression.

**From Drupal module documentation :** 
Requirements
[ImageMagick](http://www.imagemagick.org/) (or [GraphicsMagick](http://www.graphicsmagick.org/)) needs to be installed on your server and the convert (or gm) binary needs to be accessible and executable from PHP.
The PHP configuration must allow invocation of [proc_open()](http://php.net/manual/en/function.proc-open.php) (which is security-wise identical to [exec()](http://php.net/manual/en/function.exec.php)).
Consult your server administrator or hosting provider if you are unsure about these requirements.
**Contrib Module URL** : https://www.drupal.org/project/imagemagick

**Test :** 
Im using ddev in my personal, it's already set in my server. However, it needs to be checked on the server side.